### PR TITLE
Look for merge conflict markers at the beginning of the line rather than anywhere

### DIFF
--- a/conflictFinder
+++ b/conflictFinder
@@ -2,14 +2,14 @@
 set -eu
 
 if
-    grep -lr -R --exclude-dir={node_modules,vendor,.git} --exclude=conflictFinder '$<<<<<<<' .;
+    grep -lr -R --exclude-dir={node_modules,vendor,.git} --exclude=conflictFinder '^<<<<<<<' .;
 then
     printf "\033[1;31mFound merge conflicts.\033[0m\n"
     exit 1;
 fi
 
 if
-    grep -lr -R --exclude-dir={node_modules,vendor,.git} --exclude=conflictFinder '$>>>>>>>' .;
+    grep -lr -R --exclude-dir={node_modules,vendor,.git} --exclude=conflictFinder '^>>>>>>>' .;
 then
     printf "\033[1;31mFound merge conflicts.\033[0m\n"
     exit 1;

--- a/conflictFinder
+++ b/conflictFinder
@@ -2,11 +2,19 @@
 set -eu
 
 if
-    grep -lr -R --exclude-dir={node_modules,vendor,.git} --exclude=conflictFinder '<<<<<<<' .;
+    grep -lr -R --exclude-dir={node_modules,vendor,.git} --exclude=conflictFinder '$<<<<<<<' .;
 then
     printf "\033[1;31mFound merge conflicts.\033[0m\n"
     exit 1;
-else
-    printf "\033[0;32mNo merge conflicts found.\033[0m\n"
-    exit 0;
 fi
+
+if
+    grep -lr -R --exclude-dir={node_modules,vendor,.git} --exclude=conflictFinder '$>>>>>>>' .;
+then
+    printf "\033[1;31mFound merge conflicts.\033[0m\n"
+    exit 1;
+fi
+
+printf "\033[0;32mNo merge conflicts found.\033[0m\n"
+exit 0;
+


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
* Detects merge conflicts at beginning of line only.
* Added in detection of end of conflict marker.

## How Has This Been Tested

- [x] Manual Testing: 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Created a test branch with a deliberate merge conflict in: Conflict detected
* Created a branch where the file contains the text that has the conflict marker in middle of line: No conflict

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [ ] Additional Unit Tests\Integration Tests
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)