### PR TITLE
Use Actions Annotations and Add Input Options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM alpine:3.12.0
 
+RUN apk add bash
 RUN apk add grep
 
 COPY conflictFinder /conflictFinder

--- a/README.md
+++ b/README.md
@@ -28,4 +28,31 @@ jobs:
 
 On each push, it will now run the merge conflict finder
 
-<<<<<<<
+### Excludes
+You can add custom excludes to the search through the following inputs:
+
+#### `exclude_dir`
+A comma separate list of directories to ignore. The .git folder is always ignored
+
+#### `excludes`
+A comma separated list of files to ignore. Supports wildcard matching. 
+
+A workflow with the inputs could look like:
+
+```yaml
+on: [push]
+
+jobs:
+  merge_conflict_job:
+    runs-on: ubuntu-latest
+    name: Find merge conflicts
+    steps:
+      # Checkout the source code so we have some files to look at.
+      - uses: actions/checkout@v2
+      # Run the actual merge conflict finder
+      - name: Merge Conflict finder
+        uses: olivernybroe/action-conflict-finder@v1.2
+		with:
+		  exclude_dir: "path/to/ignore,path/to/ignore2"
+		  excludes: "ignore.me,*.zip"
+```

--- a/README.md
+++ b/README.md
@@ -27,3 +27,5 @@ jobs:
 ```
 
 On each push, it will now run the merge conflict finder
+
+<<<<<<<

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ jobs:
       # Run the actual merge conflict finder
       - name: Merge Conflict finder
         uses: olivernybroe/action-conflict-finder@v1.2
-		with:
-		  exclude_dir: "path/to/ignore,path/to/ignore2"
-		  excludes: "ignore.me,*.zip"
+        with:
+          exclude_dir: "path/to/ignore,path/to/ignore2"
+          excludes: "ignore.me,*.zip"
 ```

--- a/action.yml
+++ b/action.yml
@@ -3,6 +3,15 @@ description: 'Check if there are any unresolved merge conflicts'
 branding:
   icon: 'git-merge'
   color: 'gray-dark'
+inputs:
+  exclude_dir:
+    description: "Glob of directories to exclude from check"
+    required: false
+    default: 'node_modules,vendor'
+  excludes:
+    description: "Glob of files to exclude from check, supports wildcards"
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -15,4 +15,3 @@ inputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
-  

--- a/action.yml
+++ b/action.yml
@@ -15,3 +15,4 @@ inputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
+  

--- a/conflictFinder
+++ b/conflictFinder
@@ -1,9 +1,8 @@
 #!/bin/bash -l
 set -eu
-set -x
 
 grepExit () {
-	# Grep Returns 1 if not found, > 1 is an error
+	# Grep Returns 1 if pattern not found, > 1 is an error
 	if [ $1 -eq 1 ]; then
 		printf "\033[0;32mNo merge conflicts found.\033[0m\n"
 		exit 0;
@@ -12,7 +11,7 @@ grepExit () {
 	exit 1;
 }
 
-EXCLUDE=(${INPUT_EXCLUDES})
+EXCLUDE=(${INPUT_EXCLUDES/,/ })
 
 CONFLICTS="$(grep -lr -R --exclude-dir={.git,"${INPUT_EXCLUDE_DIR}"} "${EXCLUDE[@]/#/--exclude=}" -E -- '^<<<<<<<|^>>>>>>>' .)" || grepExit $?
 

--- a/conflictFinder
+++ b/conflictFinder
@@ -2,18 +2,12 @@
 set -eu
 
 if
-    grep -lr -R --exclude-dir={node_modules,vendor,.git} '^<<<<<<<' .;
+    grep -lr -R --exclude-dir={node_modules,vendor,.git} --exclide={} -E -- '^<<<<<<<|^>>>>>>>' .;
 then
     printf "\033[1;31mFound merge conflicts.\033[0m\n"
     exit 1;
 fi
-
-if
-    grep -lr -R --exclude-dir={node_modules,vendor,.git} '^>>>>>>>' .;
-then
-    printf "\033[1;31mFound merge conflicts.\033[0m\n"
-    exit 1;
-fi
+>>>>>>>
 
 printf "\033[0;32mNo merge conflicts found.\033[0m\n"
 exit 0;

--- a/conflictFinder
+++ b/conflictFinder
@@ -12,8 +12,9 @@ grepExit () {
 }
 
 EXCLUDE=(${INPUT_EXCLUDES/,/ })
+EXCLUDE_DIR=(${INPUT_EXCLUDE_DIR/,/ })
 
-CONFLICTS="$(grep -lr -R --exclude-dir={.git,"${INPUT_EXCLUDE_DIR}"} "${EXCLUDE[@]/#/--exclude=}" -E -- '^<<<<<<<|^>>>>>>>' .)" || grepExit $?
+CONFLICTS="$(grep -lr -R --exclude-dir=.git "${EXCLUDE_DIR[@]/#/--exclude-dir=}" "${EXCLUDE[@]/#/--exclude=}" -E -- '^<<<<<<<|^>>>>>>>' .)" || grepExit $?
 
 printf "\033[1;31mFound merge conflicts.\033[0m\n"
 for file in "$CONFLICTS"

--- a/conflictFinder
+++ b/conflictFinder
@@ -1,14 +1,22 @@
 #!/bin/sh -l
 set -eu
 
-if
-    grep -lr -R --exclude-dir={node_modules,vendor,.git} --exclide={} -E -- '^<<<<<<<|^>>>>>>>' .;
-then
-    printf "\033[1;31mFound merge conflicts.\033[0m\n"
-    exit 1;
-fi
->>>>>>>
+grepExit () {
+	# Grep Returns 1 if not found, > 1 is an error
+	if [ $1 -eq 1 ]; then
+		printf "\033[0;32mNo merge conflicts found.\033[0m\n"
+		exit 0;
+	fi
+	printf "\033[1;31mGrep Error.\033[0m\n"
+	exit 1;
+}
 
-printf "\033[0;32mNo merge conflicts found.\033[0m\n"
-exit 0;
+CONFLICTS="$(grep -lr -R --exclude-dir={.git,"${INPUT_EXCLUDE_DIR}"} --exclude={"${INPUT_EXCLUDES}"} -E -- '^<<<<<<<|^>>>>>>>' .)" || grepExit $?
 
+printf "\033[1;31mFound merge conflicts.\033[0m\n"
+for file in "$CONFLICTS"
+do
+	echo "::error file="$file"::Merge conflict found in $file"
+done
+
+exit 1;

--- a/conflictFinder
+++ b/conflictFinder
@@ -1,5 +1,6 @@
-#!/bin/sh -l
+#!/bin/bash -l
 set -eu
+set -x
 
 grepExit () {
 	# Grep Returns 1 if not found, > 1 is an error
@@ -11,7 +12,9 @@ grepExit () {
 	exit 1;
 }
 
-CONFLICTS="$(grep -lr -R --exclude-dir={.git,"${INPUT_EXCLUDE_DIR}"} --exclude={"${INPUT_EXCLUDES}"} -E -- '^<<<<<<<|^>>>>>>>' .)" || grepExit $?
+EXCLUDE=(${INPUT_EXCLUDES})
+
+CONFLICTS="$(grep -lr -R --exclude-dir={.git,"${INPUT_EXCLUDE_DIR}"} "${EXCLUDE[@]/#/--exclude=}" -E -- '^<<<<<<<|^>>>>>>>' .)" || grepExit $?
 
 printf "\033[1;31mFound merge conflicts.\033[0m\n"
 for file in "$CONFLICTS"


### PR DESCRIPTION
Hi @olivernybroe , I came across this action looking for an automatically find left over merge conflicts. I've made a few simple changes to meet my use cases which I think are useful to merge back into yours (rather than maintain separately). 

## High Level Changes
* Added annotations (closes #3 ). Each file that we find a merge conflict in will now be annotated saying it contains a merge conflict:
![image](https://user-images.githubusercontent.com/30645732/103464791-07b98380-4cfc-11eb-80d6-f7604667e28e.png)
* Added ability for custom excludes via workflow inputs. Default behavior is unchanged. Several use cases include skipping big or non-text files that git doesn't handle anyways or using this in a workflow that may also have other files that aren't part of the current repo included in the working directory. 


## Other notes
* There is only one grep now, changed to matching a regex that includes the two you had it searching for before. 
* Switched to bash to be able to handle arrays for the exclude inputs
* Since I am capturing grep output I also have to handle the exit codes, otherwise it will fail due to the un-handled exit code in the assignment. Grep exits with code 1 when there are no matches, so that is a success in terms of this workflow making the code a bit weird. 

I did some simple tests to make sure it catches both patterns and that the excludes work as expected. Everything seems all good on that front. Also didn't see any notable changes in execution time, but didn't test at large scale. Let me know if there are any changes to this you'd like or something doesn't seem right. 
