### PR TITLE
support more than 2 comma-delimited excludes or exclude_dir

### DIFF
--- a/conflictFinder
+++ b/conflictFinder
@@ -11,8 +11,8 @@ grepExit () {
 	exit 1;
 }
 
-EXCLUDE=(${INPUT_EXCLUDES/,/ })
-EXCLUDE_DIR=(${INPUT_EXCLUDE_DIR/,/ })
+EXCLUDE=(${INPUT_EXCLUDES//,/ })
+EXCLUDE_DIR=(${INPUT_EXCLUDE_DIR//,/ })
 
 CONFLICTS="$(grep -lr -r --exclude-dir=.git "${EXCLUDE_DIR[@]/#/--exclude-dir=}" "${EXCLUDE[@]/#/--exclude=}" -E -- '^<<<<<<<|^>>>>>>>' .)" || grepExit $?
 


### PR DESCRIPTION
When specifying more than two comma-delimited `excludes` or `exclude_dir`, only the _first_ comma is being replaced. 

~~~ yml
on: [push]

jobs:
  merge_conflict_job:
    runs-on: ubuntu-latest
    name: Find merge conflicts
    steps:
      # Checkout the source code so we have some files to look at.
      - uses: actions/checkout@v2
      # Run the actual merge conflict finder
      - name: Merge Conflict finder
        uses: olivernybroe/action-conflict-finder@v4.0
        with:
          excludes: "*.jar,*.p12,*.png,*.svg,*.tgz,*.zip"
~~~

The command that is run is:
~~~
grep -lr -r --exclude-dir=.git --exclude=*.jar --exclude=*.p12,*.png,*.svg,*.tgz,*.zip -E -- ^<<<<<<<|^>>>>>>> .
~~~

By using the `${parameter//pattern/string}` form to replace _all_ commas, we can ensure that a comma-delimited list of more than 2 entries properly expands.

> `${parameter/pattern/string}`
> `${parameter//pattern/string}`
> [...]
> In the first form above, only the first match is replaced. If there are two
> slashes separating parameter and pattern (the second form above), all
> matches of pattern are replaced with string.
>
> -- https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html

### Workaround:

supply space-delimited patterns (yaml's multiline strings `>-` [`>`=`scalar:folded`;`-`=`chomp:strip`] actually make this more readable anyway)

~~~ yml
on: [push]

jobs:
  merge_conflict_job:
    runs-on: ubuntu-latest
    name: Find merge conflicts
    steps:
      # Checkout the source code so we have some files to look at.
      - uses: actions/checkout@v2
      # Run the actual merge conflict finder
      - name: Merge Conflict finder
        uses: olivernybroe/action-conflict-finder@v4.0
        with:
          excludes: >-
            *.jar
            *.p12
            *.png
            *.svg
            *.tgz
            *.zip
~~~